### PR TITLE
Correctly scale axis around mouse

### DIFF
--- a/source/ZedGraph/ZedGraphControl.Events.cs
+++ b/source/ZedGraph/ZedGraphControl.Events.cs
@@ -958,31 +958,14 @@ namespace ZedGraph
 		{
 			if ( axis != null && zoomFraction > 0.0001 && zoomFraction < 1000.0 )
 			{
-				Scale scale = axis._scale;
-				/*
-								if ( axis.Scale.IsLog )
-								{
-									double ratio = Math.Sqrt( axis._scale._max / axis._scale._min * zoomFraction );
-
-									if ( !isZoomOnCenter )
-										centerVal = Math.Sqrt( axis._scale._max * axis._scale._min );
-
-									axis._scale._min = centerVal / ratio;
-									axis._scale._max = centerVal * ratio;
-								}
-								else
-								{
-				*/
 				double minLin = axis._scale._minLinearized;
 				double maxLin = axis._scale._maxLinearized;
-				double range = ( maxLin - minLin ) * zoomFraction / 2.0;
 
 				if ( !isZoomOnCenter )
 					centerVal = ( maxLin + minLin ) / 2.0;
 
-				axis._scale._minLinearized = centerVal - range;
-				axis._scale._maxLinearized = centerVal + range;
-				//				}
+				axis._scale._minLinearized = centerVal - ((centerVal - minLin) * zoomFraction);
+				axis._scale._maxLinearized = centerVal + ((maxLin - centerVal) * zoomFraction);
 
 				axis._scale._minAuto = false;
 				axis._scale._maxAuto = false;

--- a/unittest/AxisCustomization.cs
+++ b/unittest/AxisCustomization.cs
@@ -1,0 +1,12 @@
+﻿namespace ZedGraph
+{
+    using Ploeh.AutoFixture;
+
+    public class AxisCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customizations.Add(new AxisRelay());
+        }
+    }
+}

--- a/unittest/AxisExtensions.cs
+++ b/unittest/AxisExtensions.cs
@@ -1,0 +1,24 @@
+﻿namespace ZedGraph
+{
+    public static class AxisExtensions
+    {
+        public static Axis OfType(this Axis axis, AxisType axisType)
+        {
+            axis.Type = axisType;
+            if (axisType == AxisType.Exponent)
+            {
+                axis.Scale.Exponent = 2;
+            }
+
+            return axis;
+        }
+
+        public static Axis WithScale(this Axis axis, double min, double max)
+        {
+            axis.Scale.Min = min;
+            axis.Scale.Max = max;
+
+            return axis;
+        }
+    }
+}

--- a/unittest/AxisLabelCustomization.cs
+++ b/unittest/AxisLabelCustomization.cs
@@ -1,0 +1,13 @@
+﻿namespace ZedGraph
+{
+    using Ploeh.AutoFixture;
+    using Ploeh.AutoFixture.Kernel;
+
+    public class AxisLabelCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customize<AxisLabel>(c => c.FromFactory(new MethodInvoker(new GreedyConstructorQuery())));
+        }
+    }
+}

--- a/unittest/AxisRelay.cs
+++ b/unittest/AxisRelay.cs
@@ -1,0 +1,26 @@
+﻿namespace ZedGraph
+{
+    using System;
+
+    using Ploeh.AutoFixture.Kernel;
+
+    public class AxisRelay : ISpecimenBuilder
+    {
+        private readonly Type[] concreteTypes = { typeof(XAxis), typeof(YAxis), typeof(X2Axis), typeof(Y2Axis) };
+
+        private readonly Random random = new Random();
+
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (!typeof(Axis).Equals(request))
+            {
+                return new NoSpecimen();
+            }
+
+            int index = this.random.Next(0, this.concreteTypes.Length - 1);
+            Type concreteType = this.concreteTypes[index];
+
+            return context.Resolve(concreteType);
+        }
+    }
+}

--- a/unittest/DrawingCustomization.cs
+++ b/unittest/DrawingCustomization.cs
@@ -1,0 +1,16 @@
+﻿namespace ZedGraph
+{
+    using System.Drawing;
+
+    using Ploeh.AutoFixture;
+    using Ploeh.AutoFixture.Kernel;
+
+    public class DrawingCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customizations.Add(new PointBuilder());
+            fixture.Customizations.Add(new TypeRelay(typeof(Brush), typeof(SolidBrush)));
+        }
+    }
+}

--- a/unittest/ZedGraph.UnitTest.csproj
+++ b/unittest/ZedGraph.UnitTest.csproj
@@ -142,13 +142,20 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ValuesToolTipTests.cs" />
+    <Compile Include="AxisCustomization.cs" />
+    <Compile Include="AxisExtensions.cs" />
+    <Compile Include="AxisLabelCustomization.cs" />
+    <Compile Include="AxisRelay.cs" />
+    <Compile Include="DrawingCustomization.cs" />
     <Compile Include="OHLCBarItemTests.cs" />
     <Compile Include="PointBuilder.cs" />
     <Compile Include="ScaleTests.cs" />
+    <Compile Include="ValuesToolTipTests.cs" />
     <Compile Include="ZedGraph.UnitTest\ZGTest.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ZedGraphControlTests.cs" />
+    <Compile Include="ZedGraphCustomization.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\source\ZedGraph.csproj">

--- a/unittest/ZedGraphControlTests.cs
+++ b/unittest/ZedGraphControlTests.cs
@@ -1,0 +1,183 @@
+﻿namespace ZedGraph
+{
+    using System;
+    using System.Drawing;
+    using System.Windows.Forms;
+
+    using NUnit.Framework;
+
+    using Ploeh.AutoFixture;
+
+    [TestFixture]
+    public class ZedGraphControlTests
+    {
+        private class TestZedGraphControl : ZedGraphControl
+        {
+            public new void ZoomScale(Axis axis, double zoomFraction, double centerVal, bool isZoomOnCenter)
+            {
+                base.ZoomScale(axis, zoomFraction, centerVal, isZoomOnCenter);
+            }
+
+            public new void ZoomPane(
+                GraphPane graphPane,
+                double zoomFraction,
+                PointF centerPoint,
+                bool isZoomOnCenter,
+                bool isRefresh)
+            {
+                base.ZoomPane(graphPane, zoomFraction, centerPoint, isZoomOnCenter, isRefresh);
+            }
+
+            public new void ZedGraphControl_MouseWheel(object sender, MouseEventArgs e)
+            {
+                base.ZedGraphControl_MouseWheel(sender, e);
+            }
+        }
+
+        private const bool ZoomOnScaleCenter = false;
+
+        private const bool ZoomOnCenterValue = true;
+
+        private const double MinZoomFraction = 0.0001;
+
+        private const double MaxZoomFraction = 1000;
+
+        private readonly Random random = new Random();
+
+        [Test]
+        public void ZoomPane()
+        {
+            IFixture fixture = new Fixture().Customize(new ZedGraphCustomization());
+            var sut = new ZedGraphControl();
+        }
+
+        [Test]
+        public void MouseWheel()
+        {
+            IFixture fixture = new Fixture().Customize(new ZedGraphCustomization());
+            var sut = new TestZedGraphControl();
+        }
+
+        [Test]
+        public void ZoomScale_AxisIsNull_DoesNotThrowException()
+        {
+            IFixture fixture = new Fixture().Customize(new ZedGraphCustomization());
+            var sut = new TestZedGraphControl();
+
+            Assert.That(
+                () => sut.ZoomScale(null, fixture.Create<double>(), fixture.Create<double>(), fixture.Create<bool>()),
+                Throws.Nothing);
+        }
+
+        [Test]
+        public void ZoomScale_ZoomFractionLessThanMinimum_ScaleDoesNotChange()
+        {
+            IFixture fixture = new Fixture().Customize(new ZedGraphCustomization());
+            var min = fixture.Create<double>();
+            var max = fixture.Create<double>();
+            Axis axis = fixture.Create<Axis>()
+                .WithScale(min, max);
+            Scale scale = axis.Scale;
+            scale.MinAuto = scale.MaxAuto = true;
+            var sut = new TestZedGraphControl();
+
+            sut.ZoomScale(axis, MinZoomFraction, fixture.Create<double>(), fixture.Create<bool>());
+
+            Assert.That(scale.Min, Is.EqualTo(min), "The scale's minimum value has changed unexpectantly");
+            Assert.That(scale.Max, Is.EqualTo(max), "The scale's maximum value has changed unexpectantly");
+            Assert.That(scale.MinAuto, Is.True, "The scale's automatic minimum flag appears to have changed");
+            Assert.That(scale.MaxAuto, Is.True, "The scale's automatic maximum flag appears to have changed");
+        }
+
+        [Test]
+        public void ZoomScale_ZoomFractionGreaterThanMaximum_ScaleDoesNotChange()
+        {
+            IFixture fixture = new Fixture().Customize(new ZedGraphCustomization());
+            var min = fixture.Create<double>();
+            var max = fixture.Create<double>();
+            Axis axis = fixture.Create<Axis>()
+                .WithScale(min, max);
+            Scale scale = axis.Scale;
+            scale.MinAuto = scale.MaxAuto = true;
+            var sut = new TestZedGraphControl();
+
+            sut.ZoomScale(axis, MaxZoomFraction, fixture.Create<double>(), fixture.Create<bool>());
+
+            Assert.That(scale.Min, Is.EqualTo(min), "The scale's minimum value has changed unexpectantly");
+            Assert.That(scale.Max, Is.EqualTo(max), "The scale's maximum value has changed unexpectantly");
+            Assert.That(scale.MinAuto, Is.True, "The scale's automatic minimum flag appears to have changed");
+            Assert.That(scale.MaxAuto, Is.True, "The scale's automatic maximum flag appears to have changed");
+        }
+
+        [Test]
+        [Theory]
+        public void ZoomScale_ZoomOnScaleCenter(AxisType axisType)
+        {
+            IFixture fixture = new Fixture().Customize(new ZedGraphCustomization());
+            double zoomFraction = this.random.NextDouble() * 2;
+            var min = fixture.Create<double>();
+            double max = min + fixture.Create<double>();
+            Axis axis = fixture.Create<Axis>()
+                .OfType(axisType)
+                .WithScale(min, max);
+            Scale scale = axis.Scale;
+            double linearMax = scale.Linearize(max);
+            double linearMin = scale.Linearize(min);
+            double scaleCenter = (linearMin + linearMax) / 2;
+            double halfRange = (linearMax - linearMin) * zoomFraction / 2.0;
+            double expectedMin = scale.DeLinearize(scaleCenter - halfRange);
+            double expectedMax = scale.DeLinearize(scaleCenter + halfRange);
+            var sut = new TestZedGraphControl();
+
+            sut.ZoomScale(axis, zoomFraction, fixture.Create<double>(), ZoomOnScaleCenter);
+
+            Assert.That(
+                scale.Min,
+                Is.EqualTo(expectedMin)
+                    .Within(0.001),
+                "The scale's minimum was not the expected value");
+            Assert.That(
+                scale.Max,
+                Is.EqualTo(expectedMax)
+                    .Within(0.001),
+                "The scale's maximum was not the expected value");
+            Assert.That(scale.MinAuto, Is.False, "The scale's automatic minimum flag was not set to false");
+            Assert.That(scale.MinAuto, Is.False, "The scale's automatic maximum flag was not set to false");
+        }
+
+        [Test]
+        [Theory]
+        public void ZoomScale_ZoomOnCenterValue(AxisType axisType)
+        {
+            IFixture fixture = new Fixture().Customize(new ZedGraphCustomization());
+            double zoomFraction = this.random.NextDouble() * 2;
+            var min = fixture.Create<double>();
+            double centerValue = min + fixture.Create<double>();
+            double max = centerValue + fixture.Create<double>();
+            Axis axis = fixture.Create<Axis>()
+                .OfType(axisType)
+                .WithScale(min, max);
+            Scale scale = axis.Scale;
+            double linearMax = scale.Linearize(max);
+            double linearMin = scale.Linearize(min);
+            double expectedMin = scale.DeLinearize(centerValue - ((centerValue - linearMin) * zoomFraction));
+            double expectedMax = scale.DeLinearize(centerValue + ((linearMax - centerValue) * zoomFraction));
+            var sut = new TestZedGraphControl();
+
+            sut.ZoomScale(axis, zoomFraction, centerValue, ZoomOnCenterValue);
+
+            Assert.That(
+                scale.Min,
+                Is.EqualTo(expectedMin)
+                    .Within(0.001),
+                "The scale's minimum was not the expected value");
+            Assert.That(
+                scale.Max,
+                Is.EqualTo(expectedMax)
+                    .Within(0.001),
+                "The scale's maximum was not the expected value");
+            Assert.That(scale.MinAuto, Is.False, "The scale's automatic minimum flag was not set to false");
+            Assert.That(scale.MinAuto, Is.False, "The scale's automatic maximum flag was not set to false");
+        }
+    }
+}

--- a/unittest/ZedGraphCustomization.cs
+++ b/unittest/ZedGraphCustomization.cs
@@ -1,0 +1,17 @@
+namespace ZedGraph
+{
+    using Ploeh.AutoFixture;
+    using Ploeh.AutoFixture.AutoRhinoMock;
+
+    public class ZedGraphCustomization : CompositeCustomization
+    {
+        public ZedGraphCustomization()
+            : base(
+                new AutoRhinoMockCustomization(),
+                new AxisCustomization(),
+                new AxisLabelCustomization(),
+                new DrawingCustomization())
+        {
+        }
+    }
+}


### PR DESCRIPTION
The calculation of new axis scale min and max values when
`IsZoomOnMouseCenter = true` causes the scale to center on the mouse over
value. This causes erratic zooming behavior when using the mouse wheel
as the mouse over value continuously changes.

Instead of centering on the mouse over value, we need to center the zoom
around the mouse over value.
