### PR TITLE
Initial Port to NetStandard 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 obj/
+.vs/
 *.suo
 *.user
 

--- a/ZedGraph.sln
+++ b/ZedGraph.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2024
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZedGraph", "source\ZedGraph.csproj", "{2541686B-1673-43BF-AF89-3163945DB009}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZedGraph.Web", "web\ZedGraph.Web.csproj", "{B17D1463-CDA6-4E19-B1C9-41B82C84B7DD}"
@@ -19,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{985407
 		.nuget\nuget.targets = .nuget\nuget.targets
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZedGraph-Core", "source\ZedGraph-Core.csproj", "{D07CBF7D-5EAD-4139-B404-9C6BD14EBE58}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -50,8 +54,15 @@ Global
 		{15D66EEE-A852-4A52-89C2-83E74ECF3770}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15D66EEE-A852-4A52-89C2-83E74ECF3770}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{15D66EEE-A852-4A52-89C2-83E74ECF3770}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D07CBF7D-5EAD-4139-B404-9C6BD14EBE58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D07CBF7D-5EAD-4139-B404-9C6BD14EBE58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D07CBF7D-5EAD-4139-B404-9C6BD14EBE58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D07CBF7D-5EAD-4139-B404-9C6BD14EBE58}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {899F8E10-DF2B-437B-975C-A3602BE79354}
 	EndGlobalSection
 EndGlobal

--- a/source/Properties/AssemblyInfo.cs
+++ b/source/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System;
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "John Champion, et al." )]
 [assembly: AssemblyProduct( "ZedGraph Library" )]
-[assembly: AssemblyCopyright( "Copyright © 2003-2007 John Champion" )]
+[assembly: AssemblyCopyright( "Copyright © 2003-2018 John Champion" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 

--- a/source/ReversibleFrame.cs
+++ b/source/ReversibleFrame.cs
@@ -135,12 +135,20 @@
 
             try
             {
+#if NETSTANDARD2_0
+                IntPtr pen = CreatePen((int)PenStyle.Dot, 1, ZedGraph.ColorTranslator.ToWin32(backgroundColor));
+#else
                 IntPtr pen = CreatePen((int)PenStyle.Dot, 1, ColorTranslator.ToWin32(backgroundColor));
+#endif
 
                 int previousMode = SetROP2(new HandleRef(null, hdc), (int)mode);
                 IntPtr previousBrush = SelectObject(new HandleRef(null, hdc), new HandleRef(null, GetStockObject((int)StockObject.NullBrush)));
                 IntPtr previousPen = SelectObject(new HandleRef(null, hdc), new HandleRef(null, pen));
+#if NETSTANDARD2_0
+                SetBkColor(new HandleRef(null, hdc), ZedGraph.ColorTranslator.ToWin32(alternateColor));
+#else
                 SetBkColor(new HandleRef(null, hdc), ColorTranslator.ToWin32(alternateColor));
+#endif
 
                 Rectangle(new HandleRef(null, hdc), rectangle.X, rectangle.Y, rectangle.Right, rectangle.Bottom);
 
@@ -159,9 +167,9 @@
             }
         }
 
-        #endregion
+#endregion
 
-        #region Methods
+#region Methods
 
         [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         private static extern IntPtr CreatePen(int style, int width, int color);
@@ -184,6 +192,6 @@
         [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         private static extern int SetROP2(HandleRef dc, int drawMode);
 
-        #endregion
+#endregion
     }
 }

--- a/source/ZedGraph-Core.csproj
+++ b/source/ZedGraph-Core.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>ZedGraph</AssemblyName>
+    <RootNamespace>ZedGraph</RootNamespace>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>zedgraphkey.snk</AssemblyOriginatorKeyFile>
+    <Product>ZedGraph Library</Product>
+    <Authors>John Champion, et al.</Authors>
+    <Copyright>Copyright © 2003-2018 John Champion</Copyright>
+    <Company>John Champion, et al.</Company>
+    <AssemblyVersion>5.1.7.0</AssemblyVersion>
+    <FileVersion>5.1.7.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="IValuesToolTip.cs" />
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+    <Compile Remove="ValuesToolTip.cs" />
+    <Compile Remove="ZedGraphControl.cs" />
+    <Compile Remove="ZedGraph\DataSourcePointList.cs" />
+    <Compile Remove="ZedGraph\ZedGraphControl.ContextMenu.cs" />
+    <Compile Remove="ZedGraph\ZedGraphControl.cs" />
+    <Compile Remove="ZedGraph\ZedGraphControl.Designer.cs" />
+    <Compile Remove="ZedGraph\ZedGraphControl.Events.cs" />
+    <Compile Remove="ZedGraph\ZedGraphControl.Printing.cs" />
+    <Compile Remove="ZedGraph\ZedGraphControl.Properties.cs" />
+    <Compile Remove="ZedGraph\ZedGraphControl.ScrollBars.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Remove="ZedGraph\ZedGraphControl.resx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CoreCompat.System.Drawing.v2" Version="5.2.0-preview1-r131" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/source/ZedGraph.csproj
+++ b/source/ZedGraph.csproj
@@ -60,6 +60,7 @@
     <Compile Include="ZedGraph\BasicArrayPointList.cs" />
     <Compile Include="ZedGraph\Border.cs" />
     <Compile Include="ZedGraph\BoxObj.cs" />
+    <Compile Include="ZedGraph\ColorTranslator.cs" />
     <Compile Include="ZedGraph\HiLowBarItem.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/source/ZedGraph/ColorTranslator.cs
+++ b/source/ZedGraph/ColorTranslator.cs
@@ -1,0 +1,16 @@
+﻿using System.Drawing;
+
+namespace ZedGraph
+{
+    internal class ColorTranslator
+    {
+        private const int _win32RedShift = 0;
+        private const int _win32GreenShift = 8;
+        private const int _win32BlueShift = 16;
+
+        public static int ToWin32(Color c)
+        {
+            return c.R << _win32RedShift | c.G << _win32GreenShift | c.B << _win32BlueShift;
+        }
+    }
+}

--- a/source/ZedGraph/GraphPane.cs
+++ b/source/ZedGraph/GraphPane.cs
@@ -22,7 +22,9 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Collections;
 using System.Drawing.Imaging;
+#if !NETSTANDARD2_0
 using System.Windows.Forms;
+#endif
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;


### PR DESCRIPTION
How about porting ZedGraph as a **NetStandard 2.0** library?
Besides adding the NuGet package CoreCompat.System.Drawing.v2, adding a tiny class ```ColorTranslator``` and excluding classes/references dedicated to ```System.Windows.Forms``` this seems to be quite straight forward.