### PR TITLE
Adding .NET 5 and .NET Framework 4.8 target frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ZedGraph
 
+(Now with .NET 5 target framework)
+
 *The charting library for .NET*
 
 created by John Champion

--- a/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
+++ b/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net46;net47</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net46;net47;net48;net5.0-windows</TargetFrameworks>
     <RootNamespace>ZedGraph</RootNamespace>
     <AssemblyName>ZedGraph.WinForms</AssemblyName>
 

--- a/source/ZedGraph/ZedGraph.csproj
+++ b/source/ZedGraph/ZedGraph.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net46;net47;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net46;net47;net48;netstandard2.0;net5.0-windows</TargetFrameworks>
     <RootNamespace>ZedGraph</RootNamespace>
     <AssemblyName>ZedGraph</AssemblyName>
 


### PR DESCRIPTION
Added target framework monkiers net48 and net5.0-windows to support .NET Framework 4.8 and .NET 5 builds.  

Note that .NET 5 doesn't support adding custom winforms controls to the designer toolbox in visual studio, you have to add an empty panel instead and manually add the zed graph control as a child control.  