### PR TITLE
Add .NET 8 and .NET Framework 4.8

### DIFF
--- a/msbuild.proj
+++ b/msbuild.proj
@@ -4,12 +4,7 @@
     <Solution>ZedGraph</Solution>
   </PropertyGroup>
 
-  <Target Name="Nuget">
-    <Exec Command='nuget restore "source\$(Solution).sln"' />
-    <Exec Command='nuget restore "source\packages.config" -PackagesDirectory source\packages' />
-  </Target>
-
-  <Target Name="Build" DependsOnTargets="Nuget">
+  <Target Name="Build">
     <MsBuild BuildInParallel="True" Projects="source\$(Solution).proj" Properties="RootDirectory=$(MSBuildProjectDirectory)" StopOnFirstFailure="True" />
   </Target>
 

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<repositories>
-  <repository path="..\source\packages.config" />
-  <repository path="..\unittest\packages.config" />
-  <repository path="..\web\packages.config" />
-</repositories>

--- a/source/ZedGraph.UnitTest/AxisCustomization.cs
+++ b/source/ZedGraph.UnitTest/AxisCustomization.cs
@@ -1,6 +1,6 @@
 ﻿namespace ZedGraph
 {
-    using Ploeh.AutoFixture;
+    using AutoFixture;
 
     public class AxisCustomization : ICustomization
     {

--- a/source/ZedGraph.UnitTest/AxisLabelCustomization.cs
+++ b/source/ZedGraph.UnitTest/AxisLabelCustomization.cs
@@ -1,7 +1,7 @@
 ﻿namespace ZedGraph
 {
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Kernel;
+    using AutoFixture;
+    using AutoFixture.Kernel;
 
     public class AxisLabelCustomization : ICustomization
     {

--- a/source/ZedGraph.UnitTest/AxisRelay.cs
+++ b/source/ZedGraph.UnitTest/AxisRelay.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    using Ploeh.AutoFixture.Kernel;
+    using AutoFixture.Kernel;
 
     public class AxisRelay : ISpecimenBuilder
     {

--- a/source/ZedGraph.UnitTest/DrawingCustomization.cs
+++ b/source/ZedGraph.UnitTest/DrawingCustomization.cs
@@ -2,8 +2,8 @@
 {
     using System.Drawing;
 
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Kernel;
+    using AutoFixture;
+    using AutoFixture.Kernel;
 
     public class DrawingCustomization : ICustomization
     {

--- a/source/ZedGraph.UnitTest/PointBuilder.cs
+++ b/source/ZedGraph.UnitTest/PointBuilder.cs
@@ -17,7 +17,7 @@ namespace ZedGraph
                 return new Point(x, y);
             }
 
-            return new NoSpecimen(request);
+            return new NoSpecimen();
         }
 
         #endregion

--- a/source/ZedGraph.UnitTest/PointBuilder.cs
+++ b/source/ZedGraph.UnitTest/PointBuilder.cs
@@ -2,7 +2,7 @@ namespace ZedGraph
 {
     using System.Drawing;
 
-    using Ploeh.AutoFixture.Kernel;
+    using AutoFixture.Kernel;
 
     internal class PointBuilder : ISpecimenBuilder
     {

--- a/source/ZedGraph.UnitTest/ValuesToolTipTests.cs
+++ b/source/ZedGraph.UnitTest/ValuesToolTipTests.cs
@@ -9,13 +9,13 @@
     using NUnit.Framework;
 
     using Albedo;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoRhinoMock;
-    using Ploeh.AutoFixture.Idioms;
+    using AutoFixture;
+    using AutoFixture.AutoRhinoMock;
+    using AutoFixture.Idioms;
 
     using Rhino.Mocks;
 
-    [TestFixture]
+	[TestFixture]
     internal class ValuesToolTipTests
     {
         [Test]
@@ -65,7 +65,7 @@
             var fixture = new Fixture();
             fixture.Register(() => MockRepository.GenerateMock<Action<Control, string>>());
             fixture.Customize<Control>(c => c.OmitAutoProperties());
-            string caption = new Fixture().Create("Caption");
+            string caption = fixture.Create<string>();
             var sut = fixture.Create<ValuesToolTip>();
 
             sut.Set(caption);
@@ -79,7 +79,7 @@
             var fixture = new Fixture();
             fixture.Register(() => MockRepository.GenerateMock<Action<Control, string>>());
             fixture.Customize<Control>(c => c.OmitAutoProperties());
-            string caption = new Fixture().Create("Caption");
+            string caption = fixture.Create<string>();
             var sut = fixture.Create<ValuesToolTip>();
 
             sut.Set(caption);
@@ -96,7 +96,7 @@
             fixture.Customize<Control>(c => c.OmitAutoProperties());
             fixture.Customizations.Add(new PointBuilder());
             var point = fixture.Create<Point>();
-            string caption = new Fixture().Create("Caption");
+            string caption = fixture.Create<string>();
             var sut = fixture.Create<ValuesToolTip>();
 
             sut.Set(caption, point);
@@ -114,7 +114,7 @@
             fixture.Customizations.Add(new PointBuilder());
             var point1 = fixture.Create<Point>();
             var point2 = fixture.Create<Point>();
-            string caption = new Fixture().Create("Caption");
+            string caption = fixture.Create<string>();
             var sut = fixture.Create<ValuesToolTip>();
             Assert.That(point1, Is.Not.EqualTo(point2));
 
@@ -147,7 +147,7 @@
             fixture.Register(() => MockRepository.GenerateMock<Action<Control, string>>());
             fixture.Customize<Control>(c => c.OmitAutoProperties());
             fixture.Customizations.Add(new PointBuilder());
-            string caption = new Fixture().Create("Caption");
+            string caption = fixture.Create<string>();
             var sut = fixture.Create<ValuesToolTip>();
 
             sut.Set(caption, default(Point));

--- a/source/ZedGraph.UnitTest/ValuesToolTipTests.cs
+++ b/source/ZedGraph.UnitTest/ValuesToolTipTests.cs
@@ -8,7 +8,7 @@
 
     using NUnit.Framework;
 
-    using Ploeh.Albedo;
+    using Albedo;
     using Ploeh.AutoFixture;
     using Ploeh.AutoFixture.AutoRhinoMock;
     using Ploeh.AutoFixture.Idioms;

--- a/source/ZedGraph.UnitTest/ZGTest.cs
+++ b/source/ZedGraph.UnitTest/ZGTest.cs
@@ -1395,7 +1395,7 @@ namespace ZedGraph.UnitTest
 		Form form2;
 		GraphPane testee;
 
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void SetUp()
 		{
 			TestUtils.SetUp();

--- a/source/ZedGraph.UnitTest/ZGTest.cs
+++ b/source/ZedGraph.UnitTest/ZGTest.cs
@@ -143,7 +143,7 @@ namespace ZedGraph.UnitTest
 		{
 			form.Show();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Is an empty graph visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Is an empty graph visible?" ) );
 		}
 		#endregion
 
@@ -220,7 +220,7 @@ namespace ZedGraph.UnitTest
 
 			form.Show();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is a graph visible with 3 sets of data and text labels?" ) );
 		}
 		#endregion
@@ -373,12 +373,12 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Refresh();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is a bar graph visible with 1 set of data and value labels?  <Next Step: Resize the Graph for 3 seconds>" ) );
 
 			TestUtils.DelaySeconds( 3000 );
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the graph resize ok?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the graph resize ok?" ) );
 		}
 		#endregion
 
@@ -448,13 +448,13 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Refresh();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is a clustered bar graph having the proper number of bars per x-Axis point visible ?  <Next Step: Resize the chart>" ) );
 
 
 			TestUtils.DelaySeconds( 3000 );
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the graph resize ok with all x-Axis labels visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the graph resize ok with all x-Axis labels visible?" ) );
 		}
 		#endregion
 
@@ -501,12 +501,12 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Refresh();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is a horizontal clustered bar graph having the proper number of bars per y-Axis point visible ? <Next Step: Resize the graph>" ) );
 
 			TestUtils.DelaySeconds( 3000 );
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the graph resize ok with all y-Axis labels visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the graph resize ok with all y-Axis labels visible?" ) );
 		}
 		#endregion
 
@@ -555,12 +555,12 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Refresh();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is a stack bar graph having three bars per x-Axis point visible ?  <Next Step: Maximize the display>" ) );
 
 			TestUtils.DelaySeconds( 3000 );
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the graph resize ok with all x-Axis labels visible?  <Next Step: Add a curve>" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the graph resize ok with all x-Axis labels visible?  <Next Step: Add a curve>" ) );
 
 			LineItem curve = new LineItem( "Curve A", null, y4, Color.Black, SymbolType.TriangleDown );
 			testee.CurveList.Insert( 0, curve );
@@ -574,7 +574,7 @@ namespace ZedGraph.UnitTest
 
 			TestUtils.DelaySeconds( 3000 );
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Was a new curve displayed on top of the bars?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Was a new curve displayed on top of the bars?" ) );
 		}
 		#endregion
 
@@ -622,7 +622,7 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Refresh();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is a stack bar graph having three bars per x-Axis point visible ?  <Next Step: Fill one bar segment with a Textured Brush>" ) );
 
 			Bitmap bm = new Bitmap( @"C:\WINDOWS\FeatherTexture.bmp" );
@@ -632,7 +632,7 @@ namespace ZedGraph.UnitTest
 			form2.Refresh();
 
 			TestUtils.DelaySeconds( 3000 );
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Was the red segment replaced with one having a bitmap fill?<Next: Disappearing segments" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Was the red segment replaced with one having a bitmap fill?<Next: Disappearing segments" ) );
 
 			for ( int iCurve = 0; iCurve < 2; iCurve++ )
 			{
@@ -651,7 +651,7 @@ namespace ZedGraph.UnitTest
 				}
 			}
 			TestUtils.DelaySeconds( 1000 );
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the segments disappear uniformly while the total height stayed at +/-100%?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the segments disappear uniformly while the total height stayed at +/-100%?" ) );
 		}
 		#endregion
 
@@ -699,13 +699,13 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Refresh();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is a stack bar graph having the proper number of bars per x-Axis point visible ?  <Next Step: Resize the graph>" ) );
 
 
 			TestUtils.DelaySeconds( 3000 );
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the graph resize ok with all x-Axis labels visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the graph resize ok with all x-Axis labels visible?" ) );
 		}
 		#endregion
 
@@ -793,7 +793,7 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Refresh();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is a Sorted Overlay Stack Bar displayed with the segments in increasing value order as indicated by the embedded values? " ) );
 
 		}
@@ -843,7 +843,7 @@ namespace ZedGraph.UnitTest
 			form2.WindowState = FormWindowState.Maximized;
 			form2.Refresh();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is a horizontal stack bar graph having three bars per y-Axis point visible?  <Next Step: Re-orient the bar fill>" ) );
 
 			myCurve.Bar.Fill = new Fill( Color.White, Color.Red, 90 );
@@ -855,7 +855,7 @@ namespace ZedGraph.UnitTest
 
 			TestUtils.DelaySeconds( 3000 );
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the orientation of the fill shift from vertical to horizontal?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the orientation of the fill shift from vertical to horizontal?" ) );
 		}
 		#endregion
 
@@ -913,7 +913,7 @@ namespace ZedGraph.UnitTest
 				//DelaySeconds(	50	);
 			}
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did you see points added one by one, then deleted one by one?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did you see points added one by one, then deleted one by one?" ) );
 		}
 		#endregion
 
@@ -941,7 +941,7 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Show();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Do you see a single value in the middle of the scale ranges?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Do you see a single value in the middle of the scale ranges?" ) );
 		}
 		#endregion
 
@@ -1054,7 +1054,7 @@ namespace ZedGraph.UnitTest
 				}
 			}
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did you see an initial graph, with points disappearing one by one?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did you see an initial graph, with points disappearing one by one?" ) );
 
 			//	Go	ahead	and refigure the	axes	with the	invalid data just to check
 			testee.AxisChange( form2.CreateGraphics() );
@@ -1106,7 +1106,7 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Show();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Do you see a dual Y graph?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Do you see a dual Y graph?" ) );
 		}
 		#endregion
 
@@ -1139,7 +1139,7 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Show();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Do you see a graph with all values missing (NaN's)?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Do you see a graph with all values missing (NaN's)?" ) );
 		}
 		#endregion
 
@@ -1174,12 +1174,12 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Show();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "If you see a date graph, resize it and make" +
+			Assert.That( TestUtils.promptIfTestWorked( "If you see a date graph, resize it and make" +
 									" sure the label count is reduced to avoid overlap" ) );
 
 			TestUtils.DelaySeconds( 3000 );
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the anti-overlap work?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the anti-overlap work?" ) );
 		}
 		#endregion
 
@@ -1234,7 +1234,7 @@ namespace ZedGraph.UnitTest
 				TestUtils.DelaySeconds( 50 );
 			}
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did you see varying levels of smoothing?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did you see varying levels of smoothing?" ) );
 		}
 		#endregion
 
@@ -1283,7 +1283,7 @@ namespace ZedGraph.UnitTest
 			testee.AxisChange( form2.CreateGraphics() );
 
 			TestUtils.DelaySeconds( 3000 );
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Was a HiLow chart with a date X-Axis displayed?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Was a HiLow chart with a date X-Axis displayed?" ) );
 		}
 		#endregion
 
@@ -1327,7 +1327,7 @@ namespace ZedGraph.UnitTest
 			testee.AxisChange( form2.CreateGraphics() );
 
 			TestUtils.DelaySeconds( 3000 );
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Was the typical Error Bar chart with a date X-Axis displayed?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Was the typical Error Bar chart with a date X-Axis displayed?" ) );
 		}
 		#endregion
 
@@ -1362,7 +1362,7 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Show();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did you	get	an	X	Text axis?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did you	get	an	X	Text axis?" ) );
 
 			( myCurve.Points as PointPairList ).Clear();
 			for ( double i = 0; i < 100; i++ )
@@ -1371,11 +1371,11 @@ namespace ZedGraph.UnitTest
 			testee.AxisChange( form2.CreateGraphics() );
 			form2.Refresh();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the points fill in between the labels? (Next Resize the graph and check label overlap again)" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the points fill in between the labels? (Next Resize the graph and check label overlap again)" ) );
 
 			TestUtils.DelaySeconds( 3000 );
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Did the graph resize ok?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Did the graph resize ok?" ) );
 		}
 		#endregion
 
@@ -1531,19 +1531,19 @@ namespace ZedGraph.UnitTest
 			SetSize();
 			form2.Show();
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Do you see a dual Y graph with no axes?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Do you see a dual Y graph with no axes?" ) );
 
 			testee.Border = new Border( true, Color.Red, 3.0F );
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Pane Frame Added?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Pane Frame Added?" ) );
 
 			testee.Border = new Border( Color.Black, 1.0F );
 
 			testee.Chart.Border = new Border( true, Color.Red, 3.0F );
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Axis Frame Added?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Axis Frame Added?" ) );
 
 			testee.Chart.Border = new Border( Color.Black, 1.0F );
 
@@ -1554,7 +1554,7 @@ namespace ZedGraph.UnitTest
 			testee.Margin.Right = 50.0F;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Pane Background Filled?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Pane Background Filled?" ) );
 
 			testee.Margin.Top = 20.0F;
 			testee.Margin.Bottom = 20.0F;
@@ -1564,7 +1564,7 @@ namespace ZedGraph.UnitTest
 			testee.Chart.Fill = new Fill( Color.White, Color.LightGoldenrodYellow );
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Axis Background Filled?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Axis Background Filled?" ) );
 
 			testee.Chart.Fill.IsVisible = false;
 
@@ -1573,7 +1573,7 @@ namespace ZedGraph.UnitTest
 			testee.Title.Text = "The Title";
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Title Added?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Title Added?" ) );
 
 			testee.Title.FontSpec.FontColor = Color.Black;
 
@@ -1581,14 +1581,14 @@ namespace ZedGraph.UnitTest
 			testee.Legend.FontSpec.FontColor = Color.Red;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend Added?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend Added?" ) );
 
 			testee.Legend.FontSpec.FontColor = Color.Black;
 
 			testee.Legend.Border = new Border( true, Color.Red, 3.0F );
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend Frame Added?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend Frame Added?" ) );
 
 			testee.Legend.Border = new Border( Color.Black, 1.0F );
 
@@ -1596,40 +1596,40 @@ namespace ZedGraph.UnitTest
 			testee.Legend.Fill.Color = Color.LightGoldenrodYellow;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend Fill Added?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend Fill Added?" ) );
 
 			testee.Legend.Position = LegendPos.InsideBotLeft;
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend Moved to Inside Bottom Left?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend Moved to Inside Bottom Left?" ) );
 
 			testee.Legend.Position = LegendPos.InsideBotRight;
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend Moved to Inside Bottom Right?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend Moved to Inside Bottom Right?" ) );
 
 			testee.Legend.Position = LegendPos.InsideTopLeft;
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend Moved to Inside Top Left?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend Moved to Inside Top Left?" ) );
 
 			testee.Legend.Position = LegendPos.InsideTopRight;
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend	Moved to Inside	Top Right?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend	Moved to Inside	Top Right?" ) );
 
 			testee.Legend.Position = LegendPos.Left;
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend	Moved to Left?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend	Moved to Left?" ) );
 
 			testee.Legend.Position = LegendPos.Right;
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend	Moved to Right?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend	Moved to Right?" ) );
 
 			testee.Legend.Position = LegendPos.Top;
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend	Moved to Top?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend	Moved to Top?" ) );
 
 			testee.Legend.IsHStack = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Legend	Horizontal Stacked?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Legend	Horizontal Stacked?" ) );
 			testee.Legend.Fill.Type = FillType.None;
 
 			/////////	X	AXIS /////////////////////////////////////////////////////////////////////////
@@ -1638,70 +1638,70 @@ namespace ZedGraph.UnitTest
 			testee.XAxis.Color = Color.Red;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis Visible?" ) );
 
 			testee.XAxis.Title.Text = "X Axis Title";
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis Title Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis Title Visible?" ) );
 
 			//testee.XAxis.TicPenWidth	= 3.0F;
 			testee.XAxis.MajorGrid.IsZeroLine = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis ZeroLine Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis ZeroLine Visible?" ) );
 
 			testee.XAxis.MajorGrid.IsZeroLine = false;
 			//testee.XAxis.TicPenWidth	= 1.0F;
 			testee.XAxis.MajorTic.IsOutside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis major tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis major tics Visible?" ) );
 
 			testee.XAxis.MinorTic.IsOutside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis minor tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis minor tics Visible?" ) );
 
 			testee.XAxis.MajorTic.IsInside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis Inside tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis Inside tics Visible?" ) );
 
 			testee.XAxis.MajorTic.IsOpposite = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis Opposite tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis Opposite tics Visible?" ) );
 
 			testee.XAxis.MinorTic.IsInside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis Minor Inside tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis Minor Inside tics Visible?" ) );
 
 			testee.XAxis.MinorTic.IsOpposite = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis Minor Opposite tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis Minor Opposite tics Visible?" ) );
 
 			testee.XAxis.MajorTic.PenWidth = 1.0F;
 			testee.XAxis.Color = Color.Black;
 			testee.XAxis.MajorGrid.IsVisible = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis Grid Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis Grid Visible?" ) );
 
 			testee.XAxis.MajorGrid.PenWidth = 1.0F;
 			testee.XAxis.MajorGrid.Color = Color.Black;
 			testee.XAxis.Scale.IsReverse = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis Reversed?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis Reversed?" ) );
 
 			testee.XAxis.Scale.IsReverse = false;
 			testee.XAxis.Type = AxisType.Log;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "X Axis Log?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "X Axis Log?" ) );
 
 			testee.XAxis.Type = AxisType.Linear;
 
@@ -1713,70 +1713,70 @@ namespace ZedGraph.UnitTest
 			testee.YAxis.Color = Color.Red;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis Visible?" ) );
 
 			testee.YAxis.Title.Text = "Y Axis	Title";
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis Title Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis Title Visible?" ) );
 
 			//testee.YAxis.TicPenWidth	= 3.0F;
 			testee.YAxis.MajorGrid.IsZeroLine = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis ZeroLine Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis ZeroLine Visible?" ) );
 
 			testee.YAxis.MajorGrid.IsZeroLine = false;
 			//testee.YAxis.TicPenWidth	= 1.0F;
 			testee.YAxis.MajorTic.IsOutside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis major tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis major tics Visible?" ) );
 
 			testee.YAxis.MinorTic.IsOutside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis minor tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis minor tics Visible?" ) );
 
 			testee.YAxis.MajorTic.IsInside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis Inside tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis Inside tics Visible?" ) );
 
 			testee.YAxis.MajorTic.IsOpposite = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis Opposite tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis Opposite tics Visible?" ) );
 
 			testee.YAxis.MinorTic.IsInside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis Minor Inside tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis Minor Inside tics Visible?" ) );
 
 			testee.YAxis.MinorTic.IsOpposite = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis Minor Opposite tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis Minor Opposite tics Visible?" ) );
 
 			testee.YAxis.MajorTic.PenWidth = 1.0F;
 			testee.YAxis.Color = Color.Black;
 			testee.YAxis.MajorGrid.IsVisible = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis Grid Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis Grid Visible?" ) );
 
 			testee.YAxis.MajorGrid.PenWidth = 1.0F;
 			testee.YAxis.MajorGrid.Color = Color.Black;
 			testee.YAxis.Scale.IsReverse = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis Reversed?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis Reversed?" ) );
 
 			testee.YAxis.Scale.IsReverse = false;
 			testee.YAxis.Type = AxisType.Log;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y Axis Log?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y Axis Log?" ) );
 
 			testee.YAxis.Type = AxisType.Linear;
 
@@ -1788,70 +1788,70 @@ namespace ZedGraph.UnitTest
 			testee.Y2Axis.Color = Color.Red;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis Visible?" ) );
 
 			testee.Y2Axis.Title.Text = "Y2	Axis Title";
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis Title Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis Title Visible?" ) );
 
 			//testee.Y2Axis.TicPenWidth	=	3.0F;
 			testee.Y2Axis.MajorGrid.IsZeroLine = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis ZeroLine Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis ZeroLine Visible?" ) );
 
 			testee.Y2Axis.MajorGrid.IsZeroLine = false;
 			//testee.Y2Axis.TicPenWidth	=	1.0F;
 			testee.Y2Axis.MajorTic.IsOutside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis major tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis major tics Visible?" ) );
 
 			testee.Y2Axis.MinorTic.IsOutside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis minor tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis minor tics Visible?" ) );
 
 			testee.Y2Axis.MajorTic.IsInside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis Inside tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis Inside tics Visible?" ) );
 
 			testee.Y2Axis.MajorTic.IsOpposite = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis Opposite tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis Opposite tics Visible?" ) );
 
 			testee.Y2Axis.MinorTic.IsInside = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis Minor Inside tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis Minor Inside tics Visible?" ) );
 
 			testee.Y2Axis.MinorTic.IsOpposite = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis Minor Opposite tics Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis Minor Opposite tics Visible?" ) );
 
 			testee.Y2Axis.MajorTic.PenWidth = 1.0F;
 			testee.Y2Axis.Color = Color.Black;
 			testee.Y2Axis.MajorGrid.IsVisible = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis Grid Visible?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis Grid Visible?" ) );
 
 			testee.Y2Axis.MajorGrid.PenWidth = 1.0F;
 			testee.Y2Axis.MajorGrid.Color = Color.Black;
 			testee.Y2Axis.Scale.IsReverse = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis Reversed?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis Reversed?" ) );
 
 			testee.Y2Axis.Scale.IsReverse = false;
 			testee.Y2Axis.Type = AxisType.Log;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked( "Y2 Axis Log?" ) );
+			Assert.That( TestUtils.promptIfTestWorked( "Y2 Axis Log?" ) );
 
 			testee.Y2Axis.Type = AxisType.Linear;
 
@@ -1872,8 +1872,8 @@ namespace ZedGraph.UnitTest
 				TestUtils.DelaySeconds( 50 );
 			}
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
-				"Did Fonts Rotate & Axes Accomodate them?" ) );
+			Assert.That( TestUtils.promptIfTestWorked(
+				"Did Fonts Rotate & Axes Accommodate them?" ) );
 
 			testee.XAxis.Scale.FontSpec.Angle = 0;
 			testee.YAxis.Scale.FontSpec.Angle = 90.0F;
@@ -1891,7 +1891,7 @@ namespace ZedGraph.UnitTest
 				TestUtils.DelaySeconds( 50 );
 			}
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Did Axis Titles Rotate and the AxisRect adjust properly?" ) );
 
 			testee.XAxis.Scale.FontSpec.Angle = 0;
@@ -1917,14 +1917,14 @@ namespace ZedGraph.UnitTest
 			text.FontSpec.FontColor = Color.Red;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is TextObj Centered on Graph?" ) );
 
 			text.FontSpec.FontColor = Color.Black;
 			text.FontSpec.Border = new Border( true, Color.Red, 3.0F );
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Does TextObj have a Border?" ) );
 
 			text.FontSpec.Border = new Border( Color.Black, 1.0F );
@@ -1933,21 +1933,21 @@ namespace ZedGraph.UnitTest
 			text.FontSpec.Fill.Type = FillType.Brush;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Is TextObj background filled?" ) );
 
 			text.FontSpec.Size = 20.0F;
 			text.FontSpec.Family = "Garamond";
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Large Garamond Font?" ) );
 
 			text.FontSpec.IsUnderline = true;
 			text.FontSpec.IsItalic = true;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Text Underlined & italic?" ) );
 
 			text.FontSpec.IsItalic = false;
@@ -1958,21 +1958,21 @@ namespace ZedGraph.UnitTest
 			text.Location.CoordinateFrame = CoordType.AxisXYScale;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Centered at (75, 0.0)?" ) );
 
 			text.Location.AlignH = AlignH.Right;
 			text.Location.AlignV = AlignV.Top;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Top-Right	at (75, 0.0)?" ) );
 
 			text.Location.AlignH = AlignH.Left;
 			text.Location.AlignV = AlignV.Bottom;
 
 			form2.Refresh();
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Bottom-Left at (75, 0.0)?" ) );
 
 			for ( float angle = 0.0F; angle <= 360.0F; angle += 10.0F )
@@ -1983,7 +1983,7 @@ namespace ZedGraph.UnitTest
 				TestUtils.DelaySeconds( 50 );
 			}
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Text Rotate with Bottom-Left at (75, 0.5)?" ) );
 
 			testee.Fill.Type = FillType.Brush;
@@ -2005,7 +2005,7 @@ namespace ZedGraph.UnitTest
 
 			TestUtils.waitForUserOK = userOK;
 
-			Assert.IsTrue( TestUtils.promptIfTestWorked(
+			Assert.That( TestUtils.promptIfTestWorked(
 				"Did Everything look ok?" ) );
 		}
 		#endregion

--- a/source/ZedGraph.UnitTest/ZedGraph.UnitTest.csproj
+++ b/source/ZedGraph.UnitTest/ZedGraph.UnitTest.csproj
@@ -1,33 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <ProjectType>Local</ProjectType>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>ZedGraph.Tests</AssemblyName>
-    <AssemblyOriginatorKeyFile></AssemblyOriginatorKeyFile>
-    <DefaultClientScript>JScript</DefaultClientScript>
-    <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
-    <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
     <OutputType>Library</OutputType>
     <RootNamespace>ZedGraph</RootNamespace>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-    <StartupObject></StartupObject>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -74,38 +51,11 @@
     <ProjectReference Include="..\ZedGraph\ZedGraph.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 2.0 %28x86%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.0 %28x86%29</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Albedo" Version="2.0.0" />
-    <PackageReference Include="AutoFixture" Version="3.51.0" />
-    <PackageReference Include="AutoFixture.AutoRhinoMocks" Version="3.51.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="3.51.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoRhinoMocks" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="RhinoMocks" Version="3.6.1" />
   </ItemGroup>
   <PropertyGroup />

--- a/source/ZedGraph.UnitTest/ZedGraph.UnitTest.csproj
+++ b/source/ZedGraph.UnitTest/ZedGraph.UnitTest.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="AutoFixture.AutoRhinoMocks" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="RhinoMocks" Version="3.6.1" />
   </ItemGroup>
   <PropertyGroup />

--- a/source/ZedGraph.UnitTest/ZedGraph.UnitTest.csproj
+++ b/source/ZedGraph.UnitTest/ZedGraph.UnitTest.csproj
@@ -1,19 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
     <ProjectType>Local</ProjectType>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{15D66EEE-A852-4A52-89C2-83E74ECF3770}</ProjectGuid>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>ZedGraph.Tests</AssemblyName>
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile></AssemblyOriginatorKeyFile>
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
@@ -21,13 +12,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>ZedGraph</RootNamespace>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-    <StartupObject>
-    </StartupObject>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>3.5</OldToolsVersion>
+    <StartupObject></StartupObject>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -43,129 +28,50 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>bin\Debug\</OutputPath>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <BaseAddress>285212672</BaseAddress>
-    <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
-    <ConfigurationOverrideFile>
-    </ConfigurationOverrideFile>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DocumentationFile>
-    </DocumentationFile>
-    <DebugSymbols>true</DebugSymbols>
+    <ConfigurationOverrideFile></ConfigurationOverrideFile>
+    <DocumentationFile></DocumentationFile>
     <FileAlignment>4096</FileAlignment>
     <NoStdLib>false</NoStdLib>
-    <NoWarn>
-    </NoWarn>
-    <Optimize>false</Optimize>
+    <NoWarn></NoWarn>
     <RegisterForComInterop>false</RegisterForComInterop>
     <RemoveIntegerChecks>false</RemoveIntegerChecks>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <WarningLevel>4</WarningLevel>
-    <DebugType>full</DebugType>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>bin\Release\</OutputPath>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <BaseAddress>285212672</BaseAddress>
-    <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
-    <ConfigurationOverrideFile>
-    </ConfigurationOverrideFile>
-    <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile>
-    </DocumentationFile>
-    <DebugSymbols>false</DebugSymbols>
+    <ConfigurationOverrideFile></ConfigurationOverrideFile>
+    <DocumentationFile></DocumentationFile>
     <FileAlignment>4096</FileAlignment>
     <NoStdLib>false</NoStdLib>
-    <NoWarn>
-    </NoWarn>
-    <Optimize>true</Optimize>
+    <NoWarn></NoWarn>
     <RegisterForComInterop>false</RegisterForComInterop>
     <RemoveIntegerChecks>false</RemoveIntegerChecks>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <WarningLevel>4</WarningLevel>
     <DebugType>none</DebugType>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Ploeh.Albedo, Version=1.0.1.0, Culture=neutral, PublicKeyToken=179ef6dd03497bbd, processorArchitecture=MSIL">
-      <HintPath>..\packages\Albedo.1.0.1\lib\net35\Ploeh.Albedo.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.34.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.34.2\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoRhinoMock, Version=3.34.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.AutoRhinoMocks.3.34.2\lib\net40\Ploeh.AutoFixture.AutoRhinoMock.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.Idioms, Version=3.34.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.Idioms.3.34.2\lib\net40\Ploeh.AutoFixture.Idioms.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
-      <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System">
+    <Reference Update="System">
       <Name>System</Name>
     </Reference>
-    <Reference Include="System.Data">
+    <Reference Update="System.Data">
       <Name>System.Data</Name>
     </Reference>
-    <Reference Include="System.Drawing">
+    <Reference Update="System.Drawing">
       <Name>System.Drawing</Name>
     </Reference>
-    <Reference Include="System.Windows.Forms">
-      <Name>System.Windows.Forms</Name>
-    </Reference>
-    <Reference Include="System.Xml">
+    <Reference Update="System.Xml">
       <Name>System.XML</Name>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AxisCustomization.cs" />
-    <Compile Include="AxisExtensions.cs" />
-    <Compile Include="AxisLabelCustomization.cs" />
-    <Compile Include="AxisRelay.cs" />
-    <Compile Include="DrawingCustomization.cs" />
-    <Compile Include="OHLCBarItemTests.cs" />
-    <Compile Include="PointBuilder.cs" />
-    <Compile Include="ScaleTests.cs" />
-    <Compile Include="ValuesToolTipTests.cs" />
-    <Compile Include="ZGTest.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ZedGraphControlTests.cs" />
-    <Compile Include="ZedGraphCustomization.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ZedGraph.WinForms\ZedGraph.WinForms.csproj">
-      <Project>{e656c1d4-95ad-4df5-810b-51a9228c5adc}</Project>
-      <Name>ZedGraph.WinForms</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\ZedGraph\ZedGraph.csproj">
-      <Project>{B99650EE-AF46-47B4-A4A9-212ADE7809B7}</Project>
-      <Name>ZedGraph</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\ZedGraph.WinForms\ZedGraph.WinForms.csproj" />
+    <ProjectReference Include="..\ZedGraph\ZedGraph.csproj" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -195,13 +101,12 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="Albedo" Version="2.0.0" />
+    <PackageReference Include="AutoFixture" Version="3.51.0" />
+    <PackageReference Include="AutoFixture.AutoRhinoMocks" Version="3.51.0" />
+    <PackageReference Include="AutoFixture.Idioms" Version="3.51.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="RhinoMocks" Version="3.6.1" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
+  <PropertyGroup />
 </Project>

--- a/source/ZedGraph.UnitTest/ZedGraph.UnitTest.csproj
+++ b/source/ZedGraph.UnitTest/ZedGraph.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <ProjectType>Local</ProjectType>
     <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>ZedGraph.Tests</AssemblyName>

--- a/source/ZedGraph.UnitTest/ZedGraphControlTests.cs
+++ b/source/ZedGraph.UnitTest/ZedGraphControlTests.cs
@@ -6,7 +6,7 @@
 
     using NUnit.Framework;
 
-    using Ploeh.AutoFixture;
+    using AutoFixture;
 
     [TestFixture]
     public class ZedGraphControlTests

--- a/source/ZedGraph.UnitTest/ZedGraphCustomization.cs
+++ b/source/ZedGraph.UnitTest/ZedGraphCustomization.cs
@@ -1,7 +1,7 @@
 namespace ZedGraph
 {
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoRhinoMock;
+    using AutoFixture;
+    using AutoFixture.AutoRhinoMock;
 
     public class ZedGraphCustomization : CompositeCustomization
     {

--- a/source/ZedGraph.UnitTest/packages.config
+++ b/source/ZedGraph.UnitTest/packages.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Albedo" version="1.0.1" targetFramework="net45" />
-  <package id="AutoFixture" version="3.34.2" targetFramework="net45" />
-  <package id="AutoFixture.AutoRhinoMocks" version="3.34.2" targetFramework="net45" />
-  <package id="AutoFixture.Idioms" version="3.34.2" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net35-client" />
-  <package id="RhinoMocks" version="3.6.1" targetFramework="net35-client" />
-</packages>

--- a/source/ZedGraph.Web/ZedGraph.Web.csproj
+++ b/source/ZedGraph.Web/ZedGraph.Web.csproj
@@ -1,74 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.50727</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{B17D1463-CDA6-4E19-B1C9-41B82C84B7DD}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ZedGraph.Web</RootNamespace>
-    <AssemblyName>ZedGraph.Web</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\zedgraphkey.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\ZedGraph.Web.XML</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net35</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
     <Reference Include="System.Design" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Web\TempFileDestructor.cs" />
-    <Compile Include="Web\ZedGraphWeb.cs" />
-    <Compile Include="Web\ZedGraphWebData.cs" />
-    <Compile Include="Web\ZedGraphWebTools.cs" />
+    <ProjectReference Include="..\ZedGraph\ZedGraph.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ZedGraph\ZedGraph.csproj">
-      <Project>{2541686B-1673-43BF-AF89-3163945DB009}</Project>
-      <Name>ZedGraph</Name>
-    </ProjectReference>
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\GitVersionTask.3.4.1\build\portable-net+sl+win+wpa+wp\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.4.1\build\portable-net+sl+win+wpa+wp\GitVersionTask.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\GitVersionTask.3.4.1\build\portable-net+sl+win+wpa+wp\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.4.1\build\portable-net+sl+win+wpa+wp\GitVersionTask.targets'))" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/source/ZedGraph.Web/packages.config
+++ b/source/ZedGraph.Web/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="GitVersionTask" version="3.4.1" targetFramework="net35" developmentDependency="true" />
-</packages>

--- a/source/ZedGraph.WinForms.nuspec
+++ b/source/ZedGraph.WinForms.nuspec
@@ -2,28 +2,53 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ZedGraph.WinForms</id>
-    <version>5.1.7</version>
-    <title />
+    <version>6.0.0-alpha0002</version>
+    <title>ZedGraph</title>
     <authors>ZedGraph Project</authors>
-    <owners />
-    <licenseUrl>http://www.gnu.org/licenses/lgpl-2.1.txt</licenseUrl>
+    <readme>README.md</readme>
+    <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/zedgraph/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>ZedGraph is a class library, user control, and web control for .net, written in C#, for drawing 2D Line, Bar, and Pie Charts. It features full, detailed customization capabilities, but most options have defaults for ease of use.</description>
     <copyright>Copyright © 2003-2018 John Champion</copyright>
-    <iconUrl>https://raw.githubusercontent.com/ZedGraph/ZedGraph/master/logo-200x200.png</iconUrl>
-    <language />
+    <icon>logo-200x200.png</icon>
 
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Windows.Forms" />
+      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net35" />
+      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net40" />
+      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net45" />
+      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net47" />
     </frameworkAssemblies>
+
     <dependencies>
-      <dependency id="ZedGraph" version="$version$" />
+      <group targetFramework="net35">
+        <dependency id="ZedGraph" version="6.0.0-alpha0002" />
+      </group>
+      <group targetFramework="net40">
+        <dependency id="ZedGraph" version="6.0.0-alpha0002" />
+      </group>
+      <group targetFramework="net45">
+        <dependency id="ZedGraph" version="6.0.0-alpha0002" />
+      </group>
+      <group targetFramework="net46">
+        <dependency id="ZedGraph" version="6.0.0-alpha0002" />
+      </group>
+      <group targetFramework="net47">
+        <dependency id="ZedGraph" version="6.0.0-alpha0002" />
+      </group>
+      <group targetFramework="net8.0-windows7.0">
+        <dependency id="ZedGraph" version="6.0.0-alpha0002" />
+      </group>
     </dependencies>
+
   </metadata>
   <files>
     <file src="ZedGraph.WinForms\bin\Release\**\ZedGraph.WinForms*.dll" target="lib" />
     <file src="ZedGraph.WinForms\bin\Release\**\ZedGraph.WinForms.XML" target="lib" />
+    <file src="..\logo-200x200.png" />
     <file src="..\CHANGELOG.md"/>
+    <file src="..\License-LGPL.txt" target="LICENSE.txt" />
+    <file src="..\README.md" />
   </files>
 </package>

--- a/source/ZedGraph.WinForms.nuspec
+++ b/source/ZedGraph.WinForms.nuspec
@@ -19,6 +19,7 @@
       <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net45" />
       <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net46" />
       <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net47" />
+      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net48" />
     </frameworkAssemblies>
 
     <dependencies>
@@ -35,6 +36,9 @@
         <dependency id="ZedGraph" version="6.0.0-alpha0002" />
       </group>
       <group targetFramework="net47">
+        <dependency id="ZedGraph" version="6.0.0-alpha0002" />
+      </group>
+      <group targetFramework="net48">
         <dependency id="ZedGraph" version="6.0.0-alpha0002" />
       </group>
       <group targetFramework="net8.0-windows7.0">

--- a/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
+++ b/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
@@ -38,10 +38,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="System.Windows.Forms" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="6.3.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
+++ b/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net46;net47;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net46;net47;net8.0-windows7.0</TargetFrameworks>
     <RootNamespace>ZedGraph</RootNamespace>
     <AssemblyName>ZedGraph.WinForms</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>
@@ -34,7 +34,7 @@
     <DocumentationFile>bin\Release\net47\ZedGraph.WinForms.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows|AnyCPU'">
-    <DocumentationFile>bin\Release\net8.0-windows\ZedGraph.WinForms.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\net8.0-windows7.0\ZedGraph.WinForms.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
+++ b/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net46;net47;net8.0-windows7.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net46;net47;net48;net8.0-windows7.0</TargetFrameworks>
     <RootNamespace>ZedGraph</RootNamespace>
     <AssemblyName>ZedGraph.WinForms</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>

--- a/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
+++ b/source/ZedGraph.WinForms/ZedGraph.WinForms.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net46;net47</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net46;net47;net8.0-windows</TargetFrameworks>
     <RootNamespace>ZedGraph</RootNamespace>
     <AssemblyName>ZedGraph.WinForms</AssemblyName>
+    <UseWindowsForms>true</UseWindowsForms>
 
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\zedgraphkey.snk</AssemblyOriginatorKeyFile>
@@ -32,13 +33,18 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net47|AnyCPU'">
     <DocumentationFile>bin\Release\net47\ZedGraph.WinForms.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows|AnyCPU'">
+    <DocumentationFile>bin\Release\net8.0-windows\ZedGraph.WinForms.xml</DocumentationFile>
+  </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="3.6.5" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ZedGraph.nuspec
+++ b/source/ZedGraph.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ZedGraph</id>
@@ -23,7 +23,10 @@
     </frameworkAssemblies>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="System.Drawing.Common" version="4.5.0" />
+        <dependency id="System.Drawing.Common" version="9.0.4" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="System.Drawing.Common" version="9.0.4" />
       </group>
     </dependencies>
   </metadata>

--- a/source/ZedGraph.nuspec
+++ b/source/ZedGraph.nuspec
@@ -1,27 +1,24 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ZedGraph</id>
-    <version>5.1.7</version>
-    <title />
+    <version>6.0.0-alpha0002</version>
+    <title>ZedGraph</title>
     <authors>ZedGraph Project</authors>
-    <owners />
-    <licenseUrl>http://www.gnu.org/licenses/lgpl-2.1.txt</licenseUrl>
+    <readme>README.md</readme>
+    <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/zedgraph/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>ZedGraph is a class library, user control, and web control for .net, written in C#, for drawing 2D Line, Bar, and Pie Charts. It features full, detailed customization capabilities, but most options have defaults for ease of use.</description>
     <copyright>Copyright © 2003-2018 John Champion</copyright>
-    <iconUrl>https://raw.githubusercontent.com/ZedGraph/ZedGraph/master/logo-200x200.png</iconUrl>
-    <language />
+    <icon>logo-200x200.png</icon>
 
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net35" />
-      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net40" />
-      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net45" />
-      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net46" />
-      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="net47" />
-    </frameworkAssemblies>
     <dependencies>
+      <group targetFramework="net35"></group>
+      <group targetFramework="net40"></group>
+      <group targetFramework="net45"></group>
+      <group targetFramework="net46"></group>
+      <group targetFramework="net47"></group>
       <group targetFramework="netstandard2.0">
         <dependency id="System.Drawing.Common" version="9.0.4" />
       </group>
@@ -29,10 +26,14 @@
         <dependency id="System.Drawing.Common" version="9.0.4" />
       </group>
     </dependencies>
+
   </metadata>
   <files>
     <file src="ZedGraph\bin\Release\**\*.dll" target="lib" />
     <file src="ZedGraph\bin\Release\**\ZedGraph.XML" target="lib" />
+    <file src="..\logo-200x200.png" />
     <file src="..\CHANGELOG.md"/>
+    <file src="..\License-LGPL.txt" target="LICENSE.txt" />
+    <file src="..\README.md" />
   </files>
 </package>

--- a/source/ZedGraph.nuspec
+++ b/source/ZedGraph.nuspec
@@ -19,6 +19,7 @@
       <group targetFramework="net45"></group>
       <group targetFramework="net46"></group>
       <group targetFramework="net47"></group>
+      <group targetFramework="net48"></group>
       <group targetFramework="netstandard2.0">
         <dependency id="System.Drawing.Common" version="9.0.4" />
       </group>

--- a/source/ZedGraph.sln
+++ b/source/ZedGraph.sln
@@ -19,6 +19,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZedGraph.WinForms", "ZedGraph.WinForms\ZedGraph.WinForms.csproj", "{E656C1D4-95AD-4DF5-810B-51A9228C5ADC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Items", "Build Items", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		..\GitVersion.yml = ..\GitVersion.yml
+		..\msbuild.proj = ..\msbuild.proj
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/source/ZedGraph.sln
+++ b/source/ZedGraph.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZedGraph", "ZedGraph\ZedGraph.csproj", "{2541686B-1673-43BF-AF89-3163945DB009}"
 EndProject
@@ -12,11 +12,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FB765DB1-ECF3-4CFB-B94F-79108CE98B12}"
 	ProjectSection(SolutionItems) = preProject
 		..\CHANGELOG.md = ..\CHANGELOG.md
-		msbuild.proj = msbuild.proj
-		packages.config = packages.config
 		..\README.md = ..\README.md
 		ZedGraph.nuspec = ZedGraph.nuspec
-		ZedGraph.proj = ZedGraph.proj
 		ZedGraph.WinForms.nuspec = ZedGraph.WinForms.nuspec
 	EndProjectSection
 EndProject

--- a/source/ZedGraph/ZedGraph.csproj
+++ b/source/ZedGraph/ZedGraph.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net46;net47;netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net46;net47;net48;netstandard2.0;net8.0</TargetFrameworks>
     <RootNamespace>ZedGraph</RootNamespace>
     <AssemblyName>ZedGraph</AssemblyName>
 

--- a/source/ZedGraph/ZedGraph.csproj
+++ b/source/ZedGraph/ZedGraph.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net46;net47;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net46;net47;netstandard2.0;net8.0</TargetFrameworks>
     <RootNamespace>ZedGraph</RootNamespace>
     <AssemblyName>ZedGraph</AssemblyName>
 
@@ -35,14 +35,19 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\ZedGraph.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+    <DocumentationFile>bin\Release\net8.0\ZedGraph.xml</DocumentationFile>
+  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="3.6.5" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="System.Drawing.Common">
-      <Version>4.5.0</Version>
+      <Version>9.0.4</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/source/ZedGraph/packages.config
+++ b/source/ZedGraph/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="GitVersionTask" version="3.4.1" targetFramework="net35-client" developmentDependency="true" />
-</packages>

--- a/source/packages.config
+++ b/source/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="GitVersionTask" version="3.6.5" />
-</packages>


### PR DESCRIPTION
This covers the addition of .NET Core 8 and other necessary things:
- Add .NET 8 and .NET Framework 4.8.
- Convert all projects to SDK-style.
- Convert from `packages.config` to `PackageReference`.
- Upgrade `System.Drawing.Common` to latest.
- Upgrade unit tests to latest NUnit.
